### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,4 @@ dependencies:
   - pip
   - yaml
   - pip:
-      - gis-metadata-parser
+      - gis-metadata-parser >= 1.2.6


### PR DESCRIPTION
Pip install of gis-metadata-parser failed on Windows 10 when the version was not specified.